### PR TITLE
Fixed table formatting (#1208)

### DIFF
--- a/reference/outlook/preview/Office.context.mailbox.md
+++ b/reference/outlook/preview/Office.context.mailbox.md
@@ -398,7 +398,7 @@ If any of the parameters exceed the specified size limits, or if an unknown para
 | `parameters.bccRecipients` | Array.&lt;String&gt; &#124; Array.&lt;[EmailAddressDetails](simple-types.md#emailaddressdetails)&gt; | An array of strings containing the email addresses or an array containing an `EmailAddressDetails` object for each of the recipients on the Bcc line. The array is limited to a maximum of 100 entries. |
 | `parameters.subject` | String | A string containing the subject of the appointment. The string is limited to a maximum of 255 characters. |
 | `parameters.htmlBody` | String | The HTML body of the appointment. The body content is limited to a maximum size of 32 KB. |
-| `parameters.attachments` | Array.&lt;Object&gt; | &lt;optional&gt; | An array of JSON objects that are either file or item attachments. |
+| `parameters.attachments` | Array.&lt;Object&gt; | An array of JSON objects that are either file or item attachments. |
 | `parameters.attachments[].type` | String | Indicates the type of attachment. Must be `file` for a file attachment or `item` for an item attachment. |
 | `parameters.attachments[].name` | String | A string that contains the name of the attachment, up to 255 characters in length.| 
 | `parameters.attachments[].url` | String | Only used if `type` is set to `file`. The URI of the location for the file. |


### PR DESCRIPTION
* Adding Outlook version to note

* Updated closeContainer doc to indicate only Outlook supports it

* Added 1.5 to Mac Outlook

* Added displayNewMessageForm to preview requirement set for Outlook

* Removed extra column from attachment row in parameter table

* Revert "Removed extra column from attachment row in parameter table"

This reverts commit b7823d1d9488172c01b7d051b8ced03005fe2f6c.

* Removed extra column from parameter table entry