### PR TITLE
Get latest

### DIFF
--- a/reference/outlook/preview/Office.context.mailbox.md
+++ b/reference/outlook/preview/Office.context.mailbox.md
@@ -392,12 +392,12 @@ If any of the parameters exceed the specified size limits, or if an unknown para
 
 |Name| Type| Description|
 |---|---|---|
-| `parameters` | Object | A dictionary of parameters describing the new appointment. |
+| `parameters` | Object | A dictionary of parameters describing the new message. |
 | `parameters.toRecipients` | Array.&lt;String&gt; &#124; Array.&lt;[EmailAddressDetails](simple-types.md#emailaddressdetails)&gt; | An array of strings containing the email addresses or an array containing an `EmailAddressDetails` object for each of the recipients on the To line. The array is limited to a maximum of 100 entries. |
 | `parameters.ccRecipients` | Array.&lt;String&gt; &#124; Array.&lt;[EmailAddressDetails](simple-types.md#emailaddressdetails)&gt; | An array of strings containing the email addresses or an array containing an `EmailAddressDetails` object for each of the recipients on the Cc line. The array is limited to a maximum of 100 entries. |
 | `parameters.bccRecipients` | Array.&lt;String&gt; &#124; Array.&lt;[EmailAddressDetails](simple-types.md#emailaddressdetails)&gt; | An array of strings containing the email addresses or an array containing an `EmailAddressDetails` object for each of the recipients on the Bcc line. The array is limited to a maximum of 100 entries. |
-| `parameters.subject` | String | A string containing the subject of the appointment. The string is limited to a maximum of 255 characters. |
-| `parameters.htmlBody` | String | The HTML body of the appointment. The body content is limited to a maximum size of 32 KB. |
+| `parameters.subject` | String | A string containing the subject of the message. The string is limited to a maximum of 255 characters. |
+| `parameters.htmlBody` | String | The HTML body of the message. The body content is limited to a maximum size of 32 KB. |
 | `parameters.attachments` | Array.&lt;Object&gt; | An array of JSON objects that are either file or item attachments. |
 | `parameters.attachments[].type` | String | Indicates the type of attachment. Must be `file` for a file attachment or `item` for an item attachment. |
 | `parameters.attachments[].name` | String | A string that contains the name of the attachment, up to 255 characters in length.| 


### PR DESCRIPTION
* Adding Outlook version to note

* Updated closeContainer doc to indicate only Outlook supports it

* Added 1.5 to Mac Outlook

* Added displayNewMessageForm to preview requirement set for Outlook

* Removed extra column from attachment row in parameter table

* Revert "Removed extra column from attachment row in parameter table"

This reverts commit b7823d1d9488172c01b7d051b8ced03005fe2f6c.

* Removed extra column from parameter table entry

* Fixed descriptions in displayNewMessageForm parameters